### PR TITLE
Add support for enum param for string values.

### DIFF
--- a/src/outformer/core/token_processors.py
+++ b/src/outformer/core/token_processors.py
@@ -1,5 +1,5 @@
 import torch
-from transformers import PreTrainedTokenizer, LogitsProcessor, StoppingCriteria
+from transformers import LogitsProcessor, PreTrainedTokenizer, StoppingCriteria
 
 
 class StringStoppingCriteria(StoppingCriteria):


### PR DESCRIPTION
## Add enum support for string fields

### Summary
Adds automatic enum value selection for string fields with `enum` constraints in JSON schemas.

### What's Changed
- **New feature**: String fields with `enum` property now select from predefined values instead of free-text generation
- **Implementation**: Uses probability-based selection - evaluates model's next-token probabilities for each enum option and picks the highest
- **Reliability**: Eliminates hallucination for categorical fields - model literally cannot generate invalid enum values

### Example
```python
schema = {
    "type": "object",
    "properties": {
        "gender": {
            "type": "string",
            "enum": ["Male", "Female"]
        }
    }
}
```

**Before**: Model might generate `"gender": "male"`, `"Other"`, or any random text
**After**: Model reliably selects either `"Male"` or `"Female"` based on context

### Technical Details
- Automatically detects `enum` property in string field schemas
- Falls back to regular string generation when no enum is present
- Works with both single-token and multi-token enum values

This makes enum fields 100% reliable while maintaining the natural language understanding for value selection.